### PR TITLE
Contractinstances

### DIFF
--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -7,8 +7,14 @@
 </template>
 
 <script setup lang="ts">
-import Header from "@/components/Header.vue";
-import Footer from "@/components/Footer.vue";
+  import Header from "@/components/Header.vue";
+  import Footer from "@/components/Footer.vue";
+  import { useStore } from "@/store";
+
+  const store = useStore();
+
+  // create contract instances with provider
+  store.dispatch("contracts/setContracts");
 </script>
 
 <style>

--- a/packages/app/src/pages/Stake.vue
+++ b/packages/app/src/pages/Stake.vue
@@ -39,10 +39,14 @@
   const connected = computed(() => store.getters.getConnected);
 
   const stake = () => {
-    store.dispatch("rewards/stake", { amount: stakeAmount.value });
+    if (connected.value) {
+      store.dispatch("rewards/stake", { amount: stakeAmount.value });
+    }
   };
   const unstake = () => {
-    store.dispatch("rewards/unstake", { amount: unstakeAmount.value })
+    if (connected.value) {
+      store.dispatch("rewards/unstake", { amount: unstakeAmount.value })
+    }
   };
   const userPosition = computed(
     () => store.getters["rewards/getUserPosition"]
@@ -51,9 +55,6 @@
   watchEffect(() => {
     if (userPosition.value) {
       formatedUserPosition.value = format(userPosition.value);
-    }
-    if (connected.value) {
-      // enable stake button
     }
   });
 </script>

--- a/packages/app/src/store/modules/contracts.ts
+++ b/packages/app/src/store/modules/contracts.ts
@@ -32,19 +32,25 @@ const getters = {
 
 const actions = {
   async setContracts({ commit, rootState }: {commit: Commit, rootState: RootState}) {
-    const provider = rootState.accounts.web3Provider;
+    let providerOrSigner = rootState.accounts.web3Provider;
+
+    // if user connected pass the signer to the contract instance.
+    if (rootState.accounts.isConnected) {
+      providerOrSigner = providerOrSigner.getSigner();
+    }
+
     try {
       commit(
         "setCAPLContract",
-        markRaw(new ethers.Contract(findObjectContract('CAPL', tokens, ChainID), caplABI, provider))
+        markRaw(new ethers.Contract(findObjectContract('CAPL', tokens, ChainID), caplABI, providerOrSigner))
       );
       commit(
         "setVaultContract",
-        markRaw(new ethers.Contract(findObjectContract('rewardsVault', contracts, ChainID), vaultABI, provider))
+        markRaw(new ethers.Contract(findObjectContract('rewardsVault', contracts, ChainID), vaultABI, providerOrSigner))
       );
       commit(
         "setRewardsContract",
-        markRaw(new ethers.Contract(findObjectContract('rewards', contracts, ChainID), rewardsABI, provider))
+        markRaw(new ethers.Contract(findObjectContract('rewards', contracts, ChainID), rewardsABI, providerOrSigner))
       );
     } catch (e) {
       console.log(e)

--- a/packages/app/src/store/modules/rewards.ts
+++ b/packages/app/src/store/modules/rewards.ts
@@ -97,6 +97,7 @@ const actions = {
   },
 
   async stake({ rootState, dispatch }: {rootState: RootState, dispatch: Dispatch}, amount: number) {
+    console.log(amount);
     // if state.rewardsContract is null, call the `setContracts` function
     if (rootState.contracts.rewardsContract === null) {
       dispatch("contracts/setContracts", null, { root: true });
@@ -122,7 +123,7 @@ const actions = {
     // claim rewards
     try {
       // @ts-ignore
-      await rewardsContract?.unstake(findObjectContract('USDC', tokens, ChainID), amount);
+      await rewardsContract?.withdraw(findObjectContract('USDC', tokens, ChainID), amount);
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
Update `setContracts` function in `contracts` module

  * For now, when the user connects, the function will pass the `signer` for getting a contract instance.
  * Before connected, we should call the `setContracts` function manually to get the instances which was get with provider.